### PR TITLE
escaped special chars in search query

### DIFF
--- a/pages/books.tsx
+++ b/pages/books.tsx
@@ -39,7 +39,10 @@ const Catalog = () => {
   //search query filters based on all fields, with memoization
   const filteredItems = useMemo(() => {
     return response.filter((item) => {
-      return new RegExp(searchValue, 'i').test(Object.values(item).toString());
+      return new RegExp(
+        searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+        'i'
+      ).test(Object.values(item).toString());
     });
   }, [response, searchValue]);
 


### PR DESCRIPTION
The previous version would crash the application whenever the user typed special regex characters (+\{}[]....). This fixes the issue by escaping any instances of these characters in the search string.